### PR TITLE
Improve Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Makefile for OpenMPI based on Intel fortran compiler
 F90 = mpif90
+CPPFLAGS =
 LIB = -mkl=parallel
 OPT = -qopenmp -i8 -xHOST
 SRC =   basis.F90 geom.F90 guess.F90 fileio.F90 int1.F90 machine.F90 main.F90 math.F90 \
@@ -18,11 +19,11 @@ OBJDIR= obj
 smash : $(OBJS)
 	$(F90) -o bin/smash $(OPT) $(OBJS) $(LIB)
 
-smash.a : $(OBJS)
-	ar rv obj/smash.a $(subst obj/start.o,,$(OBJS))
+libsmash.a : $(filter-out $(OBJDIR)/start.o,$(OBJS))
+	$(AR) $(ARFLAGS) $(OBJDIR)/libsmash.a $^
 
 $(OBJDIR)/%.o : src/%.F90
-	$(F90) $(OPT) -module $(OBJDIR) -o $@ -c $<
+	$(F90) $(CPPFLAGS) $(OPT) -I $(OBJDIR) -o $@ -c $<
 
 $(OBJ): $(addprefix src/,$(MOD))
 

--- a/Makefile.fujitsu
+++ b/Makefile.fujitsu
@@ -1,5 +1,6 @@
 # Makefile for Fujitsu compiler
 F90 = mpifrtpx
+CPPFLAGS =
 LIB = -SSL2BLAMP
 OPT = -Kfast,openmp
 SRC =   basis.F90 geom.F90 guess.F90 fileio.F90 int1.F90 machine.F90 main.F90 math.F90 \
@@ -18,11 +19,11 @@ OBJDIR= obj
 smash : $(OBJS)
 	$(F90) -o bin/smash $(OPT) $(OBJS) $(LIB)
 
-smash.a : $(OBJS)
-	ar rv obj/smash.a $(subst obj/start.o,,$(OBJS))
+libsmash.a : $(filter-out $(OBJDIR)/start.o,$(OBJS))
+	$(AR) $(ARFLAGS) $(OBJDIR)/libsmash.a $^
 
 $(OBJDIR)/%.o : src/%.F90
-	$(F90) $(OPT) -M $(OBJDIR) -o $@ -c $<
+	$(F90) $(CPPFLAGS) $(OPT) -I $(OBJDIR) -o $@ -c $<
 
 $(OBJ): $(addprefix src/,$(MOD))
 

--- a/Makefile.mpiifort
+++ b/Makefile.mpiifort
@@ -1,5 +1,6 @@
 # Makefile for Intel MPI Library (mpiifort)
-F90 = mpiifort -DILP64
+F90 = mpiifort
+CPPFLAGS = -DILP64
 LIB = -mkl=parallel
 OPT = -qopenmp -i8 -xHOST -ilp64
 SRC =   basis.F90 geom.F90 guess.F90 fileio.F90 int1.F90 machine.F90 main.F90 math.F90 \
@@ -18,11 +19,11 @@ OBJDIR= obj
 smash : $(OBJS)
 	$(F90) -o bin/smash $(OPT) $(OBJS) $(LIB)
 
-smash.a : $(OBJS)
-	ar rv obj/smash.a $(subst obj/start.o,,$(OBJS))
+libsmash.a : $(filter-out $(OBJDIR)/start.o,$(OBJS))
+	$(AR) $(ARFLAGS) $(OBJDIR)/libsmash.a $^
 
 $(OBJDIR)/%.o : src/%.F90
-	$(F90) $(OPT) -module $(OBJDIR) -o $@ -c $<
+	$(F90) $(CPPFLAGS) $(OPT) -I $(OBJDIR) -o $@ -c $<
 
 $(OBJ): $(addprefix src/,$(MOD))
 

--- a/Makefile.noMPI
+++ b/Makefile.noMPI
@@ -1,5 +1,6 @@
 # Makefile for non-MPI compiler (ifort, gfortran, nvfortran (pgfortran))
-F90 = ifort -DnoMPI
+F90 = ifort
+CPPFLAGS = -DnoMPI
 LIB = -mkl=parallel
 OPT = -qopenmp -i8 -xHOST
 #gfortran  F90 = gfortran -DnoMPI
@@ -25,12 +26,11 @@ smash : $(OBJS)
 	$(F90) -o bin/smash $(OPT) $(OBJS) $(LIB)
 #gfortran	$(F90) -o bin/smash -I $(OBJDIR) $(OPT) $(OBJS) $(LIB)
 
-smash.a : $(OBJS)
-	ar rv obj/smash.a $(subst obj/start.o,,$(OBJS))
+libsmash.a : $(filter-out $(OBJDIR)/start.o,$(OBJS))
+	$(AR) $(ARFLAGS) $(OBJDIR)/libsmash.a $^
 
 $(OBJDIR)/%.o : src/%.F90
-	$(F90) $(OPT) -module $(OBJDIR) -o $@ -c $<
-#gfortran	$(F90) $(OPT) -J$(OBJDIR) -o $@ -c $<
+	$(F90) $(CPPFLAGS) $(OPT) -I $(OBJDIR) -o $@ -c $<
 
 $(OBJ): $(addprefix src/,$(MOD))
 


### PR DESCRIPTION
* use `CPPFLAGS`, and `AR` and `ARFLAGS`
  https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
* replace `smash.a` with `libsmash.a`
* use `-I` for Fortran module file directory